### PR TITLE
Remove the feast_spark_sql_emr dependency since it's not available in…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,14 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "feast>=0.42.0",
-    "pyyaml>=5.4",
-    "feast_spark_sql_emr>=0.1.0"  # Added Spark SQL (EMR) dependency
+    "pyyaml>=5.4"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=22.0",
+    "ruff>=0.0.270"
 ]
 
 [build-system]


### PR DESCRIPTION
… PyPI